### PR TITLE
Dev: Make pytest worfklow have configurable target, uv sync groups an…

### DIFF
--- a/.github/workflows/reusable-python-unit-test.yml
+++ b/.github/workflows/reusable-python-unit-test.yml
@@ -2,9 +2,12 @@
 on:
   workflow_call:
     inputs:
-      uv_test_group_name:
+      uv_sync_groups:
         type: string
-        default: test
+        default: --all-groups
+      pytest_target:
+        type: string
+        default: ""
 jobs:
   python-unit-test:
     runs-on: ubuntu-latest
@@ -16,6 +19,9 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install the project
-        run: uv sync --group ${{  inputs.uv_test_group_name  }}
+        run: uv sync ${{  inputs.uv_sync_groups  }}
+      - name: Ensure pytest-cov is available
+        run: uv pip install pytest-cov
       - name: Run tests
-        run: uv run pytest ./tests/unit/ -v
+        run: uv run pytest ${{  inputs.pytest_target  }} -v --cov=src
+          --cov-report=term-missing


### PR DESCRIPTION
Change uv_test_group_name input to uv_sync_groups and have it now accept any string which can include any dependency groups the caller wants - rather than expecting an explicit group (i.e., allow --all-groups)

Add pytest_target input to enable configuration of the test folders to target.

Make use of pytest coverage (and include installation of it)